### PR TITLE
fix pdb selector infinite diff issue

### DIFF
--- a/pkg/genrec/pdb_handling.go
+++ b/pkg/genrec/pdb_handling.go
@@ -1,0 +1,69 @@
+package genrec
+
+import (
+	"emperror.dev/errors"
+	json "github.com/json-iterator/go"
+	"reflect"
+	"strings"
+)
+
+func isPDB(resource map[string]interface{}) bool {
+	if av, ok := resource["apiVersion"].(string); ok {
+		if strings.HasPrefix(av, "policy/") && resource["kind"] == "PodDisruptionBudget" {
+			return true
+		}
+	}
+	return false
+}
+
+func getPDBSelector(resource map[string]interface{}) interface{} {
+	if spec, ok := resource["spec"]; ok {
+		if spec, ok := spec.(map[string]interface{}); ok {
+			if selector, ok := spec["selector"]; ok {
+				return selector
+			}
+		}
+	}
+	return nil
+}
+
+func deletePDBSelector(resource map[string]interface{}) ([]byte, error) {
+	if spec, ok := resource["spec"]; ok {
+		if spec, ok := spec.(map[string]interface{}); ok {
+			delete(spec, "selector")
+		}
+	}
+
+	obj, err := json.ConfigCompatibleWithStandardLibrary.Marshal(resource)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "could not marshal byte sequence")
+	}
+
+	return obj, nil
+}
+
+func ignorePDBSelector(current, modified []byte) ([]byte, []byte, error) {
+	currentResource := map[string]interface{}{}
+	if err := json.Unmarshal(current, &currentResource); err != nil {
+		return []byte{}, []byte{}, errors.Wrap(err, "could not unmarshal byte sequence for current")
+	}
+
+	modifiedResource := map[string]interface{}{}
+	if err := json.Unmarshal(modified, &modifiedResource); err != nil {
+		return []byte{}, []byte{}, errors.Wrap(err, "could not unmarshal byte sequence for modified")
+	}
+
+	if isPDB(currentResource) && reflect.DeepEqual(getPDBSelector(currentResource), getPDBSelector(modifiedResource)) {
+		var err error
+		current, err = deletePDBSelector(currentResource)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "delete pdb selector from current")
+		}
+		modified, err = deletePDBSelector(modifiedResource)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "delete pdb selector from modified")
+		}
+	}
+
+	return current, modified, nil
+}

--- a/pkg/genrec/resources.go
+++ b/pkg/genrec/resources.go
@@ -188,6 +188,7 @@ func (rd ResourceDiffs) Issues(issuesFunc func(object client.Object) []string) [
 var calcOptions = []om.CalculateOption{
 	om.IgnoreStatusFields(),
 	om.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
+	ignorePDBSelector,
 }
 
 func (rd ResourceDiff) Apply(ctx context.Context, sc k8sutil.SchemedClient, owner client.Object) error {


### PR DESCRIPTION
The pdb diff often sees a change in the selector, even when not changed. Handle this by removing the selector from the diff.