### PR TITLE
Support non-error requeues

### DIFF
--- a/pkg/genrec/generic.go
+++ b/pkg/genrec/generic.go
@@ -81,7 +81,7 @@ type Logic[S Subject, C any] interface {
 	ExtraAnnotationsForObject(c *Context[S, C], tier, suffix string) map[string]string
 	// ApplyUnmanaged is called after all managed resources have been applied successfully, to give the Logic
 	// a chance to reconcile non-k8s resources.
-	ApplyUnmanaged() error
+	ApplyUnmanaged(*Context[S, C]) error
 }
 
 // WithoutFinalizationMixin ia a convenience type to embed in your Logic if you don't need finalization.
@@ -340,7 +340,7 @@ func (g *Reconciler[S, C]) reconcile(ctx *Context[S, C]) error {
 		}
 	}
 
-	if err = g.Logic.ApplyUnmanaged(); err != nil {
+	if err = g.Logic.ApplyUnmanaged(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/genrec/generic.go
+++ b/pkg/genrec/generic.go
@@ -192,7 +192,7 @@ func (c *Context[_, _]) ResolveSecretKeyRef(ref apiobjects.SecretKeyRef) (string
 	return "", fmt.Errorf("required secret %q or key %q not found", ref.Secret, ref.Key)
 }
 
-// SetRequeue configures the controller to requeue the same object after a certain about of time. During the lifetime
+// SetRequeue configures the controller to requeue the same object after a certain amount of time. During the lifetime
 // of a context, user code (in Logic[] implementations) may call this multiple times, and the lowest value wins.
 // Note that setting a requeue is NOT an error. And you can create a requeue for an otherwise-successful reconciliation,
 // for example because you are synchronizing non-k8s resources. If you need to abort reconciliation, use an error.


### PR DESCRIPTION
Sometimes, controllers are expected to observe and reconcile external resources which are not native to k8s, and therefore do not have watches. In doing so, user code needs to sometimes request a requeue, to ensure that they observe their own changes after making them to appropriately update status.

Kubebuilder exposes this natively, but the abstraction currently hides this. We attach a requeue delay to the context, which aggregates the minimum value requested by user code. 