### PR TITLE
allow abort/retry non-error control flow

### DIFF
--- a/pkg/genrec/generic.go
+++ b/pkg/genrec/generic.go
@@ -2,6 +2,7 @@ package genrec
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/seatgeek/k8s-reconciler-generic/apiobjects"
@@ -219,6 +220,12 @@ func (g *Reconciler[_, _]) SetupWithManager(mgr ctrl.Manager) error {
 	return cb.Complete(g)
 }
 
+// the below are not really "errors", they are special values
+// to influence the abstraction control flow:
+
+var ErrAbort = errors.New("abort reconciliation")
+var ErrRetry = errors.New("abort reconciliation with requeue")
+
 func (g *Reconciler[S, C]) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	rctx := &Context[S, C]{
 		NamespacedName: request.NamespacedName,
@@ -237,17 +244,30 @@ func (g *Reconciler[S, C]) Reconcile(ctx context.Context, request reconcile.Requ
 	if rctx.EventRecorder == nil {
 		rctx.EventRecorder = &record.FakeRecorder{}
 	}
-	var rr reconcile.Result
+
 	err, terminalState := g.reconcile(rctx)
 	g.Logic.ReconcileComplete(rctx, terminalState, err)
+
 	if err != nil {
-		return rr, err
+		if errors.Is(err, ErrAbort) {
+			return reconcile.Result{}, nil
+		} else if errors.Is(err, ErrRetry) {
+			return reconcile.Result{Requeue: true}, nil
+		} else {
+			// these are real errors that will trigger incrementing kubebuilder's
+			// controller_runtime_reconcile_errors_total metric:
+			return reconcile.Result{}, err
+		}
 	}
+
 	if rctx.RequeueAfter != nil {
-		rr.Requeue = true
-		rr.RequeueAfter = *rctx.RequeueAfter
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: *rctx.RequeueAfter,
+		}, nil
 	}
-	return rr, nil
+
+	return reconcile.Result{}, nil
 }
 
 type ReconciliationStatus string


### PR DESCRIPTION
# What

Introduce two non-fatal errors: `ErrRetry` and `ErrAbort` to the generic reconciler. When returned from `Logic[...]` methods, these cause the reconciler to abandon (interrupt) the current ongoing reconciliation, with or without a requeue (respectively).

# Why

In a previous PR (https://github.com/seatgeek/k8s-reconciler-generic/pull/7) we added non-interrupting requeues. Those are different in that they do not short-circuit the reconciliation. These new error-based control flow interruptions *do* interrupt reconciliation, e.g. in the case that Observation is impossible in the current state, but is expected to be possible later (`ErrRetry`), or some external change will cause a watch-based reconciliation later (`ErrAbort`). 

In both cases, the subtle distinction is that these are not really errors, at least not ones reported to kubebuilder. If we are alerting on kubebuilder error metrics, we don't want to see these control-flow constructs there.

