### PR TITLE
add subjectUID to logs

### DIFF
--- a/pkg/genrec/generic.go
+++ b/pkg/genrec/generic.go
@@ -314,6 +314,8 @@ func (g *Reconciler[S, C]) reconcile(ctx *Context[S, C]) (error, ReconciliationS
 		return nil, PartitionMismatch
 	}
 
+	ctx.Log = ctx.Log.WithValues("subjectUID", ctx.Subject.GetUID())
+
 	if ctx.Subject.IsSuspended() {
 		ctx.Log.Info("subject is suspended")
 		return nil, SubjectSuspended
@@ -330,7 +332,6 @@ func (g *Reconciler[S, C]) reconcile(ctx *Context[S, C]) (error, ReconciliationS
 		}
 	}
 
-	ctx.Log.Info("reconciling live object")
 	origSubject := ctx.Subject.DeepCopyObject().(S) // copy the object now to compare it later
 
 	if err = g.Logic.FillDefaults(ctx); err != nil {


### PR DESCRIPTION
In order to aggregate over logs by a specific CR, it would be necessary to conceptually `group by (cluster, namespace, name)` - or in the case of counting, to `count distinct (cluster, namespace, name)`. this is cumbersome, and in some cases (e.g. datadog) aggregations, impossible.

The subject UID is a unique string identifier per CR that is unique across space and time, so it is a great grouping key for coalescing data about each CR before aggregation.