### PR TITLE
add validating webhook binding and optional mutating webhook binding

### DIFF
--- a/pkg/genrec/webhook.go
+++ b/pkg/genrec/webhook.go
@@ -1,0 +1,61 @@
+package genrec
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type validatingWebhookShim[S Subject, C any] struct {
+	Logic[S, C]
+}
+
+func (v *validatingWebhookShim[S, C]) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return v.validate(obj)
+}
+
+func (v *validatingWebhookShim[S, C]) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+	return v.validate(newObj)
+}
+
+func (v *validatingWebhookShim[S, C]) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	// not currently configurable
+	return nil, nil
+}
+
+func (v *validatingWebhookShim[S, C]) validate(obj runtime.Object) (admission.Warnings, error) {
+	subj, ok := obj.(S)
+	if !ok {
+		return nil, fmt.Errorf("validating webhook: expected a %T but got a %T", v.Logic.NewSubject(), subj)
+	}
+	if err := v.Validate(subj); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+type mutatingWebhookShim[S Subject, C any] struct {
+	*Reconciler[S, C]
+	MutatingWebhookLogic[S, C]
+}
+
+func (m *mutatingWebhookShim[S, C]) Default(ctx context.Context, obj runtime.Object) error {
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("mutating webhook: could not find request details: %w", err)
+	}
+	subj, ok := obj.(S)
+	if !ok {
+		return fmt.Errorf("mutating webhook: expected a %T but got a %T", m.Logic.NewSubject(), subj)
+	}
+	return m.MutatingWebhookLogic.Mutate(m.newContext(ctx, types.NamespacedName{
+		Namespace: subj.GetNamespace(),
+		Name:      subj.GetName(),
+	}), req)
+}
+
+type MutatingWebhookLogic[S Subject, C any] interface {
+	Mutate(*Context[S, C], admission.Request) error
+}


### PR DESCRIPTION
Add webhook listeners for the owned types:

1. Always hook up the validating webhook to the `Logic.Validate(subject)` method. It is up to integrators to deploy the configs for the apiserver to call it, of course.
2. Optionally, you may implement the `Mutate(*Context[S, C], admission.Request) error` func in your `Logic[S]` (this makes your `Logic[S]` an implementation of `MutatingWebhookLogic[S]`). If you implement this method, the mutating ("defaulting") webhook will be bound to that method.