### PR TITLE
allow managing cluster-scoped resources with derived names

### DIFF
--- a/pkg/genrec/generic.go
+++ b/pkg/genrec/generic.go
@@ -116,6 +116,14 @@ func (c *Context[_, C]) GetConfig() C {
 	return c.Config
 }
 
+func (c *Context[_, _]) GetSubjectNamespace() string {
+	return c.Namespace
+}
+
+func (c *Context[_, _]) GetSubjectUID() types.UID {
+	return c.Subject.GetUID()
+}
+
 func (c *Context[_, _]) GetClient() *k8sutil.ContextClient {
 	return c.Client
 }


### PR DESCRIPTION
We have a use case that requires creating a cluster-scoped resource per CR. In our case, this is a `VolumeSnapshotContent`, but would apply equally to e.g. `PersistentVolume` in the case of static provisioning.

This mr makes it possible to manage a cluster-scoped resource.

1. Cluster-scoped resources _must_ be orphaned, i.e. have no `ownerReference`, because they cannot be owned by a namespaced CR. Cleanup is left as an exercise to the reader, but could be accomplished with a finalizer or some cronjob.
2. Cluster-scoped resources have a name mapping, to generate a globally unique name. Two options are provided in the library: `PrependNamespace` and `AppendUID`

The way handlers were configured was becoming unwieldy, and has been changed to use a varargs opt decorator instead. - this also deprecates `GenIf` in favor of any number of predicates.