### PR TITLE
Add PatchUpdates resource option

### DIFF
--- a/pkg/resourcemanager/handler.go
+++ b/pkg/resourcemanager/handler.go
@@ -47,6 +47,10 @@ func DeleteOnChange[C Context](opts *HandlerOpts[C]) {
 	opts.DeleteOnChange = true
 }
 
+func PatchUpdates[C Context](opts *HandlerOpts[C]) {
+	opts.PatchUpdates = true
+}
+
 func Orphan[C Context](opts *HandlerOpts[C]) {
 	opts.Orphan = true
 }


### PR DESCRIPTION
This library currently (before this MR) supports two mechanisms for applying changes to resources:

1. The normal way: effectively `kubectl replace`
2. The nuclear way: `DeleteOnChange` - does not *ever* change a resource, rather deletes it when there are changes needed. The next loop of the reconciler will see it "missing" and create it fresh in the proper configuration.

Some resources need an in-between option, more similar to `kubectl apply`. One such case, specifically, is when deploying [AWS IAM Roles via ACK](https://github.com/aws-controllers-k8s/iam-controller). This controller is somewhat misbehaved, and uses the [presence of _its own finalizer_ as a hint](https://github.com/aws-controllers-k8s/iam-controller/blob/main/pkg/resource/role/descriptor.go#L92) whether the object is under management. `kubectl replace` will delete this finalizer, causing the object to get disconnected from the underlying IAM role it created, and unable to sync changes to the role.

So, this adds an option to the resource that makes changes be submitted as narrow patches from the `original` to the `desired`, and not clobbering interim changes in `current`.