### PR TITLE
add ObserveCallback Option to NewHandler()

### DIFF
--- a/pkg/resourcemanager/handler.go
+++ b/pkg/resourcemanager/handler.go
@@ -24,7 +24,7 @@ type ResourceHandler[C Context] struct {
 type HandlerOpts[C Context] struct {
 	Requirements    []func(C) bool
 	ClusterScoped   NameMapper[C]
-	ObserveCallback func(client.Object)
+	ObserveCallback func(client.Object, C)
 	genrec.ResourceOpts
 }
 
@@ -40,11 +40,11 @@ func AppendUID[C Context](context C, name string) string {
 
 type OptsFunc[C Context] func(*HandlerOpts[C])
 
-func ObserveCallback[C Context, T client.Object](cb func(T)) OptsFunc[C] {
+func ObserveCallback[C Context, T client.Object](cb func(T, C)) OptsFunc[C] {
 	return func(opts *HandlerOpts[C]) {
-		opts.ObserveCallback = func(object client.Object) {
+		opts.ObserveCallback = func(object client.Object, c C) {
 			if t, ok := object.(T); ok {
-				cb(t)
+				cb(t, c)
 			}
 		}
 	}
@@ -101,7 +101,7 @@ func NewHandler[T any, C Context, PT interface {
 			return nil, err
 		}
 		if opts.ObserveCallback != nil {
-			opts.ObserveCallback(obj)
+			opts.ObserveCallback(obj, context)
 		}
 		return obj, nil
 	}


### PR DESCRIPTION
# what 

Add an optional `ObserveCallback` to `resourcemanager.NewHandler`

# why

It's a very common pattern to have generators and/or other logic (applyunmanaged, etc) depend on the observed state of specific resources.

Right now, it's cumbersome, and requires overriding ObserveResources. for example, if you have a `Logic[T]` that uses` resourcemanager`, you would manually implement `ObserveResources` -- and let's pretend you want to observe a deployment named `-foo`:


```go
func (l *ReconcilerLogic) ObserveResources(c *Context) (genrec.Resources, error) {

	// delegate to the resource manager:
	resources, err := l.ResourceManager.ObserveResources(c)
	if err != nil {
		return nil, fmt.Errorf("cannot observe built-in resources: %w", err)
	}


	// now unpack the things we need and place them into c.Config:
	rmap := resources.ToMap()

	fooDeploymentKey := rm.RenderResourceKey(schema.GroupKind{Group: appsv1.GroupVersion.Group, Kind: "Deployment"}, c.ObjectName("foo", ""))
	if obj, ok := rmap[fooDeploymentKey]; ok && !genrec.IsNil(obj.Object) {
		c.Config.ObservedFooDeployment = obj.Object.(*appsv1.Deployment)
	}

	return resources, nil
}
```


After this MR, this could be much simpler:

```go
rm.NewHandler("foo", "", generateFooDeployment, rm.ObserveCallback(func(d *appsv1.Deployment, c *Context){
 	c.Config.ObservedFooDeployment = d
}))
```

